### PR TITLE
fix: use configuration 'implementation' to prevent build error with AGP 7

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -1,7 +1,3 @@
-repositories{
-    jcenter()
-}
-
 dependencies {
     implementation files('libs/barcodescanner-release-2.1.7.aar')
 }

--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -6,7 +6,7 @@ repositories{
 }
 
 dependencies {
-    compile(name:'barcodescanner-release-2.1.7', ext:'aar')
+    implementation(name:'barcodescanner-release-2.1.7', ext:'aar')
 }
 
 android {

--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -1,12 +1,9 @@
 repositories{
     jcenter()
-    flatDir{
-        dirs 'libs'
-    }
 }
 
 dependencies {
-    implementation(name:'barcodescanner-release-2.1.7', ext:'aar')
+    implementation files('libs/barcodescanner-release-2.1.7.aar')
 }
 
 android {


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
Configuration `compile` is obsolete, and removed in version 7.0 of the Android Gradle plugin.

Cleanup deprecated or unused `repositories` config.

Fixes #5

### Testing
`BUILD SUCCESSFUL` with cordova-android 10 / AGP 4.2 and cordova-andoid 11 / AGP 7