### PR TITLE
Force fullscreen presentation style, like before iOS 13

### DIFF
--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -351,6 +351,8 @@ parentViewController:(UIViewController*)parentViewController
     self.viewController = [[CDVbcsViewController alloc] initWithProcessor: self alternateOverlay:self.alternateXib];
     // here we set the orientation delegate to the MainViewController of the app (orientation controlled in the Project Settings)
     self.viewController.orientationDelegate = self.plugin.viewController;
+    // force fullscreen
+    self.viewController.modalPresentationStyle = UIModalPresentationFullScreen;
 
     // delayed [self openDialog];
     [self performSelector:@selector(openDialog) withObject:nil afterDelay:1];


### PR DESCRIPTION
See issue https://github.com/phonegap/phonegap-plugin-barcodescanner/issues/814, because of the [default modal presentation style change in iOS 13](https://hacknicity.medium.com/view-controller-presentation-changes-in-ios-13-ac8c901ebc4e)