### PR TITLE
Update Android permissions and features

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,7 +43,6 @@
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/*">
       <uses-permission android:name="android.permission.CAMERA"/>
-      <uses-permission android:name="android.permission.FLASHLIGHT"/>
       <uses-feature android:name="android.hardware.camera"/>
     </config-file>
     <framework src="src/android/barcodescanner.gradle" custom="true" type="gradleReference"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -43,7 +43,6 @@
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/*">
       <uses-permission android:name="android.permission.CAMERA"/>
-      <uses-feature android:name="android.hardware.camera"/>
     </config-file>
     <framework src="src/android/barcodescanner.gradle" custom="true" type="gradleReference"/>
     <framework src="androidx.legacy:legacy-support-v4:$ANDROIDX_LEGACY_SUPPORT_V4_VERSION"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,8 @@
     </config-file>
     <config-file target="AndroidManifest.xml" parent="/*">
       <uses-permission android:name="android.permission.CAMERA"/>
+      <uses-feature android:name="android.hardware.camera" android:required="false"/>
+      <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
     </config-file>
     <framework src="src/android/barcodescanner.gradle" custom="true" type="gradleReference"/>
     <framework src="androidx.legacy:legacy-support-v4:$ANDROIDX_LEGACY_SUPPORT_V4_VERSION"/>


### PR DESCRIPTION
1. **remove `FLASHLIGHT` permission**
Since using the camera, with `CAMERA` permission, already allows to use the flashlight.
see https://stackoverflow.com/a/48553060

~2. **remove explicit `hardware.camera` feature**
The `CAMERA` permission automatically requires some camera features.
see https://developer.android.com/guide/topics/manifest/uses-feature-element#permissions
Let app developers decide whether these are required or not, set `<uses-feature>` by themselves if needed, preventing conflict with other plugins here.~

2. **declare `hardware.camera` features but to disable filtering based on the `CAMERA` permission**
The `CAMERA` permission automatically requires some camera features.
see https://developer.android.com/guide/topics/manifest/uses-feature-element#permissions

---

Related to #7 and therefore also to https://github.com/phonegap/phonegap-plugin-barcodescanner/pull/882.